### PR TITLE
FileChooser: add sorting "percent - unopened last natural"

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -198,6 +198,8 @@ function FileManager:setupLayout()
         local is_folder = lfs.attributes(file, "mode") == "directory"
         local is_not_parent_folder = BaseUtil.basename(file) ~= ".."
 
+        if not is_file and not is_folder then return true end -- virtual directory
+
         local function close_dialog_callback()
             UIManager:close(self.file_dialog)
         end

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -215,17 +215,20 @@ local FileChooser = Menu:extend{
                 local natsort
                 natsort, cache = sort.natsort_cmp(cache)
                 return function(a, b)
-                    if a.percent_finished == b.percent_finished then
+                    -- smooth 2 decmial points (0.00) instead of 16 decimal numbers
+                    local apercent = math.floor(a.percent_finished * 100) / 100
+                    local bpercent = math.floor(b.percent_finished * 100) / 100
+                    if apercent == bpercent then
                         return natsort(a.text, b.text)
                     end
-                    if a.percent_finished == 1 then
+                    if apercent == 1 then
                         return false
                     end
-                    if b.percent_finished == 1 then
+                    if bpercent == 1 then
                         return true
                     end
 
-                    return a.percent_finished > b.percent_finished
+                    return apercent > bpercent
                 end, cache
             end,
             item_func = function(item)
@@ -235,7 +238,7 @@ local FileChooser = Menu:extend{
                     local doc_settings = DocSettings:open(item.path)
                     percent_finished = doc_settings:readSetting("percent_finished")
                 end
-                item.percent_finished = percent_finished or 0
+                item.percent_finished = percent_finished or -1
             end,
             mandatory_func = function(item)
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -206,6 +206,41 @@ local FileChooser = Menu:extend{
                 return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
             end,
         },
+        percent_natural = {
+            -- sort 90% > 50% > 0% > unopened > 100%
+            text = _("percent - unopened last natural"),
+            menu_order = 90,
+            can_collate_mixed = false,
+            init_sort_func = function(cache)
+                local natsort
+                natsort, cache = sort.natsort_cmp(cache)
+                return function(a, b)
+                    if a.percent_finished == b.percent_finished then
+                        return natsort(a.text, b.text)
+                    end
+                    if a.percent_finished == 1 then
+                        return false
+                    end
+                    if b.percent_finished == 1 then
+                        return true
+                    end
+
+                    return a.percent_finished > b.percent_finished
+                end, cache
+            end,
+            item_func = function(item)
+                local percent_finished
+                item.opened = DocSettings:hasSidecarFile(item.path)
+                if item.opened then
+                    local doc_settings = DocSettings:open(item.path)
+                    percent_finished = doc_settings:readSetting("percent_finished")
+                end
+                item.percent_finished = percent_finished or 0
+            end,
+            mandatory_func = function(item)
+                return item.opened and string.format("%d %%", 100 * item.percent_finished) or "–"
+            end,
+        },
     },
 }
 

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -249,6 +249,7 @@ function CoverMenu:updateItems(select_number)
                 -- Call original function: it will create a ButtonDialog
                 -- and store it as self.file_dialog, and UIManager:show() it.
                 self.showFileDialog_orig(self, file)
+                if not self.file_dialog then return true end -- virtual directory
 
                 local bookinfo = BookInfoManager:getBookInfo(file)
                 if not bookinfo or bookinfo._is_directory then

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -222,7 +222,7 @@ function ListMenuItem:update()
     end
 
     local file_mode = lfs.attributes(self.filepath, "mode")
-    if file_mode == "directory" then
+    if file_mode == "directory" or self.entry.is_virtual_dir then
         self.is_directory = true
         -- nb items on the right, directory name on the left
         local wright = TextWidget:new{

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -683,4 +683,12 @@ function CoverBrowser:extractBooksInDirectory(path)
     end)
 end
 
+function CoverBrowser:getMatchingMetadataValues(base_dir, meta_name, filters)
+    return BookInfoManager:getMatchingMetadataValues(base_dir, meta_name, filters)
+end
+
+function CoverBrowser:getMatchingFiles(base_dir, filters)
+    return BookInfoManager:getMatchingFiles(base_dir, filters)
+end
+
 return CoverBrowser

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -460,7 +460,7 @@ function MosaicMenuItem:update()
     end
 
     local file_mode = lfs.attributes(self.filepath, "mode")
-    if file_mode == "directory" then
+    if file_mode == "directory" or self.entry.is_virtual_dir then
         self.is_directory = true
         -- Directory : rounded corners
         local margin = Screen:scaleBySize(5) -- make directories less wide


### PR DESCRIPTION
Add a sorting that sorts:
`sort 90% > 50% > 0% > unopened > 100%`
(falls back to `name (natural)` in case of same percentage

similar to how other services (like tolino and likely kobo) sort opened / reading books flat (aside from 100% still showing at the end)

Example:
![example](https://github.com/poire-z/koreader/assets/10911626/7f924834-0e28-4d23-bd55-31ba16ac5280)

(screenshot from a run on the desktop)
(Note for the "0%" volumes, it sorts 6 before 3 because 6 has `percentage 0.0030864197530864` and 3 has `percentage 0.0028248587570621`, while opened on page 1)

Edit: added a commit to smooth the percentages to the second decimal point instead of the 16 decimal points raw